### PR TITLE
Add Free Pascal compatibility

### DIFF
--- a/BoardControls.pas
+++ b/BoardControls.pas
@@ -56,7 +56,7 @@ threadvar
 implementation
 
 
-uses Math,System.Generics.Collections,Winapi.Windows;
+uses Math,SysUtils;
 
 
 
@@ -356,7 +356,7 @@ end;
    // if not IsValidMove(Ax,AY,APBoard.PlayerOnTurn,APBoard) then Exit;
     new(LBoard);
     try
-      MoveMemory(LBoard,apBoard,Sizeof(TBoard));
+      Move(apBoard^, LBoard^, SizeOf(TBoard));
 
        lBoard.Occupation[AX,AY]:=APBoard.PlayerOnTurn;
        X:=AX-1;

--- a/DataTypes.pas
+++ b/DataTypes.pas
@@ -1,8 +1,11 @@
 unit DataTypes;
 
 interface
-  uses
-    VCL.Graphics,Classes;
+{$IFDEF FPC}
+  uses Graphics,Classes;
+{$ELSE}
+  uses VCL.Graphics,Classes;
+{$ENDIF}
   const
 
 //////////////////////////////////

--- a/Display.pas
+++ b/Display.pas
@@ -1,7 +1,11 @@
 unit Display;
 
 interface
+{$IFDEF FPC}
+uses Classes,Graphics, DataTypes,ExtCtrls,SysUtils;
+{$ELSE}
 uses Classes,Windows, VCL.Graphics, DataTypes,VCL.ExtCtrls,SysUtils;
+{$ENDIF}
 procedure PaintEmptyBoard(ADrawImage:TImage;ABoardSize:Integer);
 function CalcStoneSize(ADrawImage:TImage;ABoardSize:Integer):Double;inline;
 procedure PaintOccupation(ADrawImage:TImage;ABoardSize:Integer;ABoard:PBoard);

--- a/GtpWrapperThread.pas
+++ b/GtpWrapperThread.pas
@@ -4,8 +4,13 @@ unit GtpWrapperThread;
 interface
 
 uses
-  Classes,DataTypes,Windows,
-  VCL.StdCtrls,SysUtils,GameControl;
+  Classes,DataTypes,
+  {$IFDEF FPC}
+  StdCtrls,
+  {$ELSE}
+  Windows, VCL.StdCtrls,
+  {$ENDIF}
+  SysUtils,GameControl;
  procedure HandleCommand(ACommand:TStringList);
  function ParseParams(Acommand:String):TStringList;
  function IsKnownCommand(ACommand:String):Boolean;

--- a/Threading.Playout.pas
+++ b/Threading.Playout.pas
@@ -2,7 +2,12 @@ unit Threading.Playout;
 
 interface
 uses
-  System.Classes,MonteCarlo,UCTree,Tree,DataTypes,BoardControls;
+  {$IFDEF FPC}
+  Classes,
+  {$ELSE}
+  System.Classes,
+  {$ENDIF}
+  MonteCarlo,UCTree,Tree,DataTypes,BoardControls;
 
 type
   TOnThreadFinishedCallBack = procedure(ACaller:TTreeNode<TUCTNode>;APlayouts:Integer;AWhiteWins:Integer;AScoreSum:Double) of object;

--- a/Tree.pas
+++ b/Tree.pas
@@ -2,10 +2,11 @@ unit Tree;
 
 interface
 uses
-  System.Classes,
-  System.Math,
-  System.Generics.Defaults,
-  System.Generics.Collections;
+  {$IFDEF FPC}
+  Classes, Math, Generics.Defaults, Generics.Collections;
+  {$ELSE}
+  System.Classes, System.Math, System.Generics.Defaults, System.Generics.Collections;
+  {$ENDIF}
 type
   ICompareableData = interface
   ['{C7B36C09-DFE7-4177-8634-7C865FE7FDB6}']

--- a/UCT.pas
+++ b/UCT.pas
@@ -1,7 +1,12 @@
 unit UCT;
 
 interface
-  uses DataTypes,BoardControls,Windows,SyncObjs;
+  uses DataTypes,BoardControls,
+  {$IFDEF FPC}
+  SyncObjs;
+  {$ELSE}
+  Windows,SyncObjs;
+  {$ENDIF}
 
   const
   MIN_TREE_WIDTH = 1;

--- a/UCTree.pas
+++ b/UCTree.pas
@@ -2,7 +2,7 @@ unit UCTree;
 
 interface
 uses
-  Tree,DataTypes,System.Math;
+  Tree,DataTypes,{$IFDEF FPC}Math{$ELSE}System.Math{$ENDIF};
 type
   //TODO
   //Choose best move to get childs from !!!!
@@ -116,7 +116,7 @@ end;
         Wins:=ARootNode.Childs[i].Content.GetData.WinsWhite
       else
         Wins:=ARootNode.Childs[i].Content.GetData.WinsBlack;
-      CurWR:=Ply ;//   ... /how to Choose best move for playing?=!=!=!=!=!=!ß?!?=!==!
+      CurWR:=Ply ;//   ... /how to Choose best move for playing?=!=!=!=!=!=!ÃŸ?!?=!==!
       if CurWR>BestWR then
     //  if Ply > ALPHA_AMAF_MINMOVES then
       begin

--- a/UCTreeThread.pas
+++ b/UCTreeThread.pas
@@ -2,7 +2,13 @@ unit UCTreeThread;
 
 interface
 uses
-  UCTree,Tree,BoardControls,DataTypes,MonteCarlo,System.Classes,System.SysUtils,Threading.Playout;
+  UCTree,Tree,BoardControls,DataTypes,MonteCarlo,
+  {$IFDEF FPC}
+  Classes,SysUtils,
+  {$ELSE}
+  System.Classes,System.SysUtils,
+  {$ENDIF}
+  Threading.Playout;
 type
 
   TUCTreeThread = class (TThread)

--- a/Unittests/Test.BoardControls.pas
+++ b/Unittests/Test.BoardControls.pas
@@ -9,13 +9,32 @@ unit Test.BoardControls;
 
 }
 interface
+{$IFDEF FPC}
+uses
+  Classes, SysUtils, fpcunit, testutils, testregistry,
+  DataTypes,
+  BoardControls;
+{$ELSE}
 uses
   DUnitX.TestFramework,
   DataTypes,
   BoardControls;
+{$ENDIF}
 
 type
-
+{$IFDEF FPC}
+  TTestBoardControls = class(TTestCase)
+  protected
+    procedure SetUp; override;
+    procedure TearDown; override;
+  published
+    procedure TestIsSuicide;
+    procedure TestReverseColor;
+    procedure TestWouldCaptureAnyThing;
+    procedure TestCountLiberties;
+    procedure TestIsSelfAtari;
+  end;
+{$ELSE}
   [TestFixture]
   TTestBoardControls = class(TObject)
   public
@@ -40,8 +59,45 @@ type
     [Test]
     procedure TestIsSelfAtari;
   end;
+{$ENDIF}
 
 implementation
+{$IFDEF FPC}
+type
+  Assert = class
+  public
+    class procedure AreEqual(const Expected, Actual: Integer); overload; static;
+    class procedure AreEqual(const Expected, Actual: Boolean); overload; static;
+    class procedure AreEqualMemory(Expected, Actual: Pointer; Size: PtrUInt); static;
+    class procedure IsTrue(Condition: Boolean); static;
+    class procedure IsFalse(Condition: Boolean); static;
+  end;
+
+class procedure Assert.AreEqual(const Expected, Actual: Integer);
+begin
+  AssertEquals(Expected, Actual);
+end;
+
+class procedure Assert.AreEqual(const Expected, Actual: Boolean);
+begin
+  AssertEquals(Expected, Actual);
+end;
+
+class procedure Assert.AreEqualMemory(Expected, Actual: Pointer; Size: PtrUInt);
+begin
+  AssertTrue(CompareMem(Expected, Actual, Size));
+end;
+
+class procedure Assert.IsTrue(Condition: Boolean);
+begin
+  AssertTrue(Condition);
+end;
+
+class procedure Assert.IsFalse(Condition: Boolean);
+begin
+  AssertFalse(Condition);
+end;
+{$ENDIF}
 procedure TTestBoardControls.TestWouldCaptureAnyThing;
 var
   LX,LY:Integer;
@@ -250,5 +306,8 @@ end;
 
 
 initialization
+{$IFDEF FPC}
+  RegisterTest(TTestBoardControls);
+{$ENDIF}
 
 end.

--- a/Unittests/UTestGoEngine.dpr
+++ b/Unittests/UTestGoEngine.dpr
@@ -1,5 +1,18 @@
 program UTestGoEngine;
 
+{$IFDEF FPC}
+{$mode delphi}{$H+}
+{$IFDEF UNIX}
+  cthreads,
+{$ENDIF}
+uses
+  Classes, SysUtils, fpcunit, testregistry,
+  Test.BoardControls;
+begin
+  RunRegisteredTests;
+end.
+{$ELSE}
+
 {$IFNDEF TESTINSIGHT}
 {$APPTYPE CONSOLE}
 {$ENDIF}{$STRONGLINKTYPES ON}
@@ -57,3 +70,4 @@ begin
       System.Writeln(E.ClassName, ': ', E.Message);
   end;
 end.
+{$ENDIF}


### PR DESCRIPTION
## Summary
- support FPC/Lazarus by using Graphics/ExtCtrls etc when FPC is defined
- drop Windows-specific dependency and copy with `Move`
- introduce FPC wrappers for assertions
- add FPC test runner path and register tests

## Testing
- `fpc Unittests/UTestGoEngine.dpr` *(fails: `fpc: command not found`)*